### PR TITLE
Derek/navdata updates

### DIFF
--- a/data/unit_test/navdata/navdata_only_header.csv
+++ b/data/unit_test/navdata/navdata_only_header.csv
@@ -1,0 +1,1 @@
+﻿names,integers,floats,strings

--- a/data/unit_test/navdata/navdata_test_nan.csv
+++ b/data/unit_test/navdata/navdata_test_nan.csv
@@ -1,7 +1,7 @@
 ﻿names,integers,floats,strings
-ab,10,0.5,gps
+ab,10,0.5,NaN
 cde,2,nan,glonass
 alpha,45,0.3,galileo
 epsilon,67,0.99,gps
-gamma,nan,0.45,gps
+nan,nan,0.45,gps
 xyzuvw,300,0.74,galileo

--- a/gnss_lib_py/algorithms/snapshot.py
+++ b/gnss_lib_py/algorithms/snapshot.py
@@ -51,14 +51,9 @@ def solve_wls(measurements, weight_type = None,
 
     """
 
-    if "x_sv_m" not in measurements.rows:
-        raise KeyError("x_sv_m (ECEF x position of sv) missing.")
-    if "y_sv_m" not in measurements.rows:
-        raise KeyError("y_sv_m (ECEF y position of sv) missing.")
-    if "z_sv_m" not in measurements.rows:
-        raise KeyError("z_sv_m (ECEF z position of sv) missing.")
-    if "b_sv_m" not in measurements.rows:
-        raise KeyError("b_sv_m (clock bias of sv) missing.")
+    # check that all necessary rows exist
+    measurements.in_rows(["x_sv_m","y_sv_m","z_sv_m","b_sv_m",
+                          "gps_millis"])
 
     unique_timesteps = np.unique(measurements["gps_millis",:])
 

--- a/gnss_lib_py/parsers/android.py
+++ b/gnss_lib_py/parsers/android.py
@@ -47,14 +47,18 @@ class AndroidDerived2021(NavData):
         derived_timestamps = pd_df['millisSinceGpsEpoch'].unique()
         indexes = np.searchsorted(derived_timestamps, derived_timestamps)
         map_derived_time_back = dict(zip(derived_timestamps, derived_timestamps[indexes-1]))
-        pd_df['millisSinceGpsEpoch'] = np.array(list(map(lambda v: map_derived_time_back[v], pd_df['millisSinceGpsEpoch'])))
-
+        pd_df['millisSinceGpsEpoch'] = np.array(list(map(lambda v: map_derived_time_back[v],
+                                                pd_df['millisSinceGpsEpoch'])))
 
         # Correction 5 implemented verbatim from competition tips
         if remove_timing_outliers:
             delta_millis = pd_df['millisSinceGpsEpoch'] - pd_df['receivedSvTimeInGpsNanos'] / 1e6
             where_good_signals = (delta_millis > 0) & (delta_millis < 300)
             pd_df = pd_df[where_good_signals].copy()
+            if np.all(~where_good_signals):
+                warnings.warn("All data removed due to timing outliers,"
+                            + " try setting remove_timing_outliers to"
+                            + " False", RuntimeWarning)
 
         super().__init__(pandas_df=pd_df)
 

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -60,12 +60,6 @@ class NavData():
         """Postprocess loaded data. Optional in subclass
         """
 
-    def _build_navdata(self):
-        """Build attributes for NavData.
-
-        """
-        self.array = np.zeros((0,0), dtype=self.arr_dtype)
-
     def from_csv_path(self, csv_path, **kwargs):
         """Build attributes of NavData using csv file.
 
@@ -129,354 +123,6 @@ class NavData():
 
         for row_num in range(numpy_array.shape[0]):
             self[str(row_num)] = numpy_array[row_num,:]
-
-    @staticmethod
-    def _row_map():
-        """Map of column names from loaded to gnss_lib_py standard
-
-        Initializes as an emptry dictionary, must be reimplemented for
-        custom parsers.
-
-        Returns
-        -------
-        row_map : Dict
-            Dictionary of the form {old_name : new_name}
-        """
-
-        row_map = {}
-
-        return row_map
-
-    def pandas_df(self):
-        """Return pandas DataFrame equivalent to class
-
-        Returns
-        -------
-        df : pd.DataFrame
-            DataFrame with data, including strings as strings
-        """
-
-        df_list = []
-        for row in self.rows:
-            df_list.append(np.atleast_1d(self[row]))
-
-        # transpose list to conform to Pandas input
-        df_list = [list(x) for x in zip(*df_list)]
-
-        dframe = pd.DataFrame(df_list,columns=self.rows)
-
-        return dframe
-
-    def get_strings(self, key):
-        """Return list of strings for given key
-
-        Parameters
-        ----------
-        key : string for column name required as string
-
-        Returns
-        -------
-        values_str : np.ndarray
-            1D array with string entries corresponding to dataset
-        """
-        values_int = self.array[self.map[key],:].astype(int)
-        values_str = values_int.astype(object, copy=True)
-        # True by default but making explicit for clarity
-        for str_key, str_val in self.str_map[key].items():
-            values_str[values_int==str_key] = str_val
-        return values_str
-
-    def save_csv(self, output_path="navdata.csv"): #pragma: no cover
-        """Save data as csv
-
-        Parameters
-        ----------
-        output_path : string
-            Path where csv should be saved
-        """
-        pd_df = self.pandas_df()
-        pd_df.to_csv(output_path)
-
-    def _parse_key_idx(self, key_idx):
-        """Break down input queries to relevant row and column indices
-
-        Parameters
-        ----------
-        key_idx : str/list/tuple/slice/int
-            Query for array items
-
-        Returns
-        -------
-        rows : slice/list
-            Rows to extract from the array
-        cols : slice/list
-            Columns to extract from the array
-        """
-        if isinstance(key_idx, str):
-            rows = [self.map[key_idx]]
-            cols = slice(None, None)
-        elif isinstance(key_idx, list) and isinstance(key_idx[0], str):
-            rows = [self.map[k] for k in key_idx]
-            cols = slice(None, None)
-        elif isinstance(key_idx, slice):
-            rows = key_idx
-            cols = slice(None, None)
-        elif isinstance(key_idx, int):
-            rows = [key_idx]
-            cols = slice(None, None)
-        else:
-            if isinstance(key_idx[1], int):
-                cols = [key_idx[1]]
-            else:
-                cols = key_idx[1]
-
-            rows = []
-            if isinstance(key_idx[0], slice):
-                rows = key_idx[0]
-            elif isinstance(key_idx[0], int):
-                rows = [key_idx[0]]
-            else:
-                if not isinstance(key_idx[0],list):
-                    row_key = [key_idx[0]]
-                else:
-                    row_key = key_idx[0]
-                for key in row_key:
-                    rows.append(self.map[key])
-        return rows, cols
-
-    def _get_str_rows(self, rows):
-        """Checks which input rows contain string elements
-
-        Parameters
-        ----------
-        rows : slice/list
-            Rows to check for string elements
-
-        Returns
-        -------
-        row_list : list
-            Input rows, strictly in list format
-        row_str : list
-            List of boolean values indicating which rows contain strings
-        """
-        _row_idx_str_bool = self._row_idx_str_bool
-        if isinstance(rows, slice):
-            slice_idx = rows.indices(self.shape[0])
-            row_list = np.arange(slice_idx[0], slice_idx[1], slice_idx[2])
-            row_str = [_row_idx_str_bool[row] for row in row_list]
-        else:
-            row_list = list(rows)
-            row_str = [_row_idx_str_bool[row] for row in rows]
-        return row_list, row_str
-
-    def _get_set_str_rows(self, rows, new_value):
-        """Checks which output rows contain string elements given input.
-
-        If the row used to be string values but now is numeric, this
-        function also empties the corresponding dictionary in str_map.
-
-        Parameters
-        ----------
-        rows : slice/list
-            Rows to check for string elements
-        new_value : np.ndarray/list/int
-            Values to be added to self.array attribute
-
-        Returns
-        -------
-        row_list : list
-            Input rows, strictly in list format
-        row_str_new : list
-            List of boolean values indicating which of the new rows
-            contain strings.
-        """
-
-        row_list, row_str_existing = self._get_str_rows(rows)
-
-        if isinstance(new_value, np.ndarray) and (new_value.dtype in (object,str) \
-                        or np.issubdtype(new_value.dtype,np.dtype('U'))):
-            if type(new_value.item(0)) in (int, float):
-                row_str_new = [False]*len(row_list)
-            else:
-                row_str_new = [True]*len(row_list)
-        elif isinstance(np.asarray(new_value).item(0), str):
-            raise RuntimeError("Cannot set a row with list of strings, \
-                             please use np.ndarray with dtype=object")
-        else:
-            row_str_new = [False]*len(row_list)
-
-        for row_idx, row in enumerate(row_list):
-            if row_str_existing[row_idx] and not row_str_new[row_idx]:
-                # changed from string to numeric
-                self.str_map[self.inv_map[row]] = {}
-
-        return row_list, row_str_new
-
-    def __getitem__(self, key_idx):
-        """Return item indexed from class
-
-        Parameters
-        ----------
-        key_idx : str/list/tuple/slice/int
-            Query for array items
-
-        Returns
-        -------
-        arr_slice : np.ndarray
-            Array of data containing row names and time indexed
-            columns. The return is squeezed meaning that all dimensions
-            of the output that are length of one are removed
-        """
-        rows, cols = self._parse_key_idx(key_idx)
-        row_list, row_str = self._get_str_rows(rows)
-        assert np.all(row_str) or np.all(np.logical_not(row_str)), \
-                "Cannot assign/return combination of strings and numbers"
-        if np.all(row_str):
-            # Return sliced strings
-            arr_slice = np.atleast_2d(np.empty_like(self.array[rows, cols], dtype=object))
-            for row_num, row in enumerate(row_list):
-                str_arr = self.get_strings(self.inv_map[row])
-                arr_slice[row_num, :] = str_arr[cols]
-        else:
-            arr_slice = self.array[rows, cols]
-
-        # remove all dimensions of length one
-        arr_slice = np.squeeze(arr_slice)
-
-        return arr_slice
-
-    def __setitem__(self, key_idx, new_value):
-        """Add/update rows.
-
-        __setitem__ expects that the shape of the value being passed
-        matches the shape of the internal arrays that have to be set.
-        So, if 2 variable types (rows) at 10 instances (columns) need to
-        be set, the input new_value must be of shape (2, 10).
-        If the shape is (10, 2) the assignment operator will raise a
-        ValueError. This applies to all types of value assignments.
-
-        Parameters
-        ----------
-        key_idx : str/list/tuple/slice/int
-            Query for array items to set
-        new_value : np.ndarray/list/int
-            Values to be added to self.array attribute
-
-        """
-        if isinstance(key_idx, int) and len(self.map)<=key_idx:
-            raise KeyError('Row indices must be strings when assigning new values')
-        if isinstance(key_idx, slice) and len(self.map)==0:
-            raise KeyError('Row indices must be strings when assigning new values')
-        if isinstance(key_idx, str) and key_idx not in self.map:
-            #Creating an entire new row
-            if isinstance(new_value, np.ndarray) \
-                    and (new_value.dtype in (object,str) \
-                    or np.issubdtype(new_value.dtype,np.dtype('U'))):                # Adding string values
-                # string values
-                new_value = new_value.astype(str)
-                new_str_vals = len(np.unique(new_value))*np.ones(np.shape(new_value),
-                                    dtype=self.arr_dtype)
-                new_str_vals = self._str_2_val(new_str_vals, new_value, key_idx)
-                if self.array.shape == (0,0):
-                    # if empty array, start from scratch
-                    self.array = np.reshape(new_str_vals, [1, -1])
-                else:
-                    # if array is not empty, add to it
-                    self.array = np.vstack((self.array, np.reshape(new_str_vals, [1, -1])))
-                self.map[key_idx] = self.shape[0]-1
-            else:
-                # numeric values
-                if not isinstance(new_value, int) \
-                and not isinstance(new_value, float) \
-                and new_value.size > 0:
-                    assert not isinstance(np.asarray(new_value).item(0), str), \
-                            "Cannot set a row with list of strings, \
-                            please use np.ndarray with dtype=object"
-                # Adding numeric values
-                self.str_map[key_idx] = {}
-                if self.array.shape == (0,0):
-                    # if empty array, start from scratch
-                    self.array = np.reshape(new_value, (1,-1))
-                    # have to explicitly convert to float in case
-                    # numbers were interpretted as integers
-                    self.array = self.array.astype(self.arr_dtype)
-                else:
-                    # if array is not empty, add to it
-                    self.array = np.vstack((self.array, np.empty([1, len(self)])))
-                    self.array[-1, :] = np.reshape(new_value, -1)
-                self.map[key_idx] = self.shape[0]-1
-        else:
-            # Updating existing rows or columns
-            rows, cols = self._parse_key_idx(key_idx)
-            row_list, row_str = self._get_set_str_rows(rows,new_value)
-            assert np.all(row_str) or np.all(np.logical_not(row_str)), \
-                "Cannot assign/return combination of strings and numbers"
-            if np.all(row_str):
-                assert isinstance(new_value, np.ndarray) \
-                   and (new_value.dtype in (object,str) \
-                     or np.issubdtype(new_value.dtype,np.dtype('U'))), \
-                        "String assignment only supported for ndarray of type object"
-                inv_map = self.inv_map
-                new_value = np.atleast_2d(new_value)
-                new_str_vals = np.ones_like(new_value, dtype=self.arr_dtype)
-                for row_num, row in enumerate(row_list):
-                    key = inv_map[row]
-                    new_value_row = new_value[row_num , :]
-                    new_str_vals_row = new_str_vals[row_num, :]
-                    new_str_vals[row_num, :] = self._str_2_val(new_str_vals_row,
-                                                    new_value_row, key)
-                self.array[rows, cols] = new_str_vals
-            else:
-                if not isinstance(new_value, int):
-                    assert not isinstance(np.asarray(new_value)[0], str), \
-                            "Please use dtype=object for string assignments"
-                self.array[rows, cols] = new_value
-
-    def _str_2_val(self, new_str_vals, new_value, key):
-        """Convert string valued arrays to values for storing in array
-
-        Parameters
-        ----------
-        new_str_vals : np.ndarray
-            Array of dtype=self.arr_dtype where numeric values are to be
-            stored
-        new_value : np.ndarray
-            Array of dtype=object, containing string values that are to
-            be converted
-        key : string
-            Key indicating row where string to numeric conversion is
-            required
-        """
-        if key in self.map:
-            # Key already exists, update existing string value dictionary
-            inv_str_map = {v: k for k, v in self.str_map[key].items()}
-            string_vals = np.unique(new_value)
-            str_map_dict = self.str_map[key]
-            total_str = len(self.str_map[key])
-            for str_val in string_vals:
-                if str_val not in inv_str_map.keys():
-                    str_map_dict[total_str] = str_val
-                    new_str_vals[new_value==str_val] = total_str
-                    total_str += 1
-                else:
-                    new_str_vals[new_value==str_val] = inv_str_map[str_val]
-            self.str_map[key] = str_map_dict
-        else:
-            string_vals = np.unique(new_value)
-            str_dict = dict(enumerate(string_vals))
-            self.str_map[key] = str_dict
-            new_str_vals = len(string_vals)*np.ones(np.shape(new_value),
-                                                   dtype=self.arr_dtype)
-            # Set unassigned value to int not accessed by string map
-            for str_key, str_val in str_dict.items():
-                if new_str_vals.size == 1:
-                    new_str_vals = np.array(str_key,dtype=self.arr_dtype)
-                else:
-                    new_str_vals[new_value==str_val] = str_key
-            # Copy set to false to prevent memory overflows
-            new_str_vals = np.round(new_str_vals.astype(self.arr_dtype,
-                                                        copy=False))
-        return new_str_vals
 
     def add(self, csv_path=None, pandas_df=None, numpy_array=None):
         """Add new timesteps to existing array
@@ -634,93 +280,6 @@ class NavData():
                                                 condition="between")
             yield delta_t, new_navdata
 
-    def __iter__(self):
-        """Initialize iterator over NavData (iterates over all columns)
-
-        Returns
-        -------
-        self: gnss_lib_py.parsers.NavData
-            Instantiation of NavData class with iteration initialized
-        """
-        self.curr_col = 0
-        self.num_cols = np.shape(self.array)[1]
-        return self
-
-    def __next__(self):
-        """Method to get next item when iterating over NavData class
-
-        Returns
-        -------
-        x_curr : gnss_lib_py.parsers.NavData
-            Current column (based on iteration count)
-        """
-        if self.curr_col >= self.num_cols:
-            raise StopIteration
-        x_curr = self.copy(rows=None, cols=self.curr_col)
-        self.curr_col += 1
-        return x_curr
-
-    def __str__(self):
-        str_out = str(self.pandas_df())
-        str_out = str_out.replace("DataFrame","NavData")
-        str_out = str_out.replace("Columns","Rows")
-        # swap rows and columns when printing for NavData consistency
-        str_out = re.sub(r"(.*)\[(\d+)\srows\sx\s(\d+)\scolumns\](.*)",
-                         r'\g<1>[\g<3> rows x \g<2> columns]\g<4>',
-                         str_out)
-        return str_out
-
-    def __len__(self):
-        """Return length of class
-
-        Returns
-        -------
-        length : int
-            Number of time steps in NavData
-        """
-        length = np.shape(self.array)[1]
-        return length
-
-    @property
-    def shape(self):
-        """Return shape of class
-
-        Returns
-        -------
-        shp : tuple
-            (M, N), M is number of rows and N number of time steps
-        """
-        shp = np.shape(self.array)
-        return shp
-
-    @property
-    def rows(self):
-        """Return all row names in instance as a list
-
-        Returns
-        -------
-        rows : list
-            List of row names in NavData
-        """
-        rows = list(self.map.keys())
-        return rows
-
-
-    @property
-    def _row_idx_str_bool(self):
-        """Dictionary of index : if data entry is string.
-
-        Row has string values if the string map is nonempty for a
-        given row.
-
-        Returns
-        -------
-        _row_idx_str_bool : Dict
-            Dictionary of whether data at row number key is string or not
-        """
-        _row_idx_str_bool = {self.map[k]: bool(len(self.str_map[k])) for k in self.str_map}
-        return _row_idx_str_bool
-
     def is_str(self, row_name):
         """Check whether a row contained string values.
 
@@ -743,18 +302,6 @@ class NavData():
         contains_str = self._row_idx_str_bool[self.map[row_name]]
 
         return contains_str
-
-    @property
-    def inv_map(self):
-        """Inverse dictionary map for label and row_number map
-
-        Returns
-        -------
-        inv_map: Dict
-            Dictionary of row_number : label
-        """
-        inv_map = {v: k for k, v in self.map.items()}
-        return inv_map
 
     def rename(self, mapper=None, inplace=False):
         """Rename rows of NavData class.
@@ -1006,3 +553,455 @@ class NavData():
         if len(missing_rows) > 0:
             raise KeyError(", ".join(missing_rows) + " row(s) are" \
                            + " missing from NavData object.")
+
+    def pandas_df(self):
+        """Return pandas DataFrame equivalent to class
+
+        Returns
+        -------
+        df : pd.DataFrame
+            DataFrame with data, including strings as strings
+        """
+
+        df_list = []
+        for row in self.rows:
+            df_list.append(np.atleast_1d(self[row]))
+
+        # transpose list to conform to Pandas input
+        df_list = [list(x) for x in zip(*df_list)]
+
+        dframe = pd.DataFrame(df_list,columns=self.rows)
+
+        return dframe
+
+    def save_csv(self, output_path="navdata.csv"): #pragma: no cover
+        """Save data as csv
+
+        Parameters
+        ----------
+        output_path : string
+            Path where csv should be saved
+        """
+        pd_df = self.pandas_df()
+        pd_df.to_csv(output_path)
+
+    @property
+    def inv_map(self):
+        """Inverse dictionary map for label and row_number map
+
+        Returns
+        -------
+        inv_map: Dict
+            Dictionary of row_number : label
+        """
+        inv_map = {v: k for k, v in self.map.items()}
+        return inv_map
+
+    @property
+    def shape(self):
+        """Return shape of class
+
+        Returns
+        -------
+        shp : tuple
+            (M, N), M is number of rows and N number of time steps
+        """
+        shp = np.shape(self.array)
+        return shp
+
+    @property
+    def rows(self):
+        """Return all row names in instance as a list
+
+        Returns
+        -------
+        rows : list
+            List of row names in NavData
+        """
+        rows = list(self.map.keys())
+        return rows
+
+    @property
+    def _row_idx_str_bool(self):
+        """Dictionary of index : if data entry is string.
+
+        Row has string values if the string map is nonempty for a
+        given row.
+
+        Returns
+        -------
+        _row_idx_str_bool : Dict
+            Dictionary of whether data at row number key is string or not
+        """
+        _row_idx_str_bool = {self.map[k]: bool(len(self.str_map[k])) for k in self.str_map}
+        return _row_idx_str_bool
+
+    def __getitem__(self, key_idx):
+        """Return item indexed from class
+
+        Parameters
+        ----------
+        key_idx : str/list/tuple/slice/int
+            Query for array items
+
+        Returns
+        -------
+        arr_slice : np.ndarray
+            Array of data containing row names and time indexed
+            columns. The return is squeezed meaning that all dimensions
+            of the output that are length of one are removed
+        """
+        rows, cols = self._parse_key_idx(key_idx)
+        row_list, row_str = self._get_str_rows(rows)
+        assert np.all(row_str) or np.all(np.logical_not(row_str)), \
+                "Cannot assign/return combination of strings and numbers"
+        if np.all(row_str):
+            # Return sliced strings
+            arr_slice = np.atleast_2d(np.empty_like(self.array[rows, cols], dtype=object))
+            for row_num, row in enumerate(row_list):
+                str_arr = self._get_strings(self.inv_map[row])
+                arr_slice[row_num, :] = str_arr[cols]
+        else:
+            arr_slice = self.array[rows, cols]
+
+        # remove all dimensions of length one
+        arr_slice = np.squeeze(arr_slice)
+
+        return arr_slice
+
+    def __setitem__(self, key_idx, new_value):
+        """Add/update rows.
+
+        __setitem__ expects that the shape of the value being passed
+        matches the shape of the internal arrays that have to be set.
+        So, if 2 variable types (rows) at 10 instances (columns) need to
+        be set, the input new_value must be of shape (2, 10).
+        If the shape is (10, 2) the assignment operator will raise a
+        ValueError. This applies to all types of value assignments.
+
+        Parameters
+        ----------
+        key_idx : str/list/tuple/slice/int
+            Query for array items to set
+        new_value : np.ndarray/list/int
+            Values to be added to self.array attribute
+
+        """
+        if isinstance(key_idx, int) and len(self.map)<=key_idx:
+            raise KeyError('Row indices must be strings when assigning new values')
+        if isinstance(key_idx, slice) and len(self.map)==0:
+            raise KeyError('Row indices must be strings when assigning new values')
+        if isinstance(key_idx, str) and key_idx not in self.map:
+            #Creating an entire new row
+            if isinstance(new_value, np.ndarray) \
+                    and (new_value.dtype in (object,str) \
+                    or np.issubdtype(new_value.dtype,np.dtype('U'))):                # Adding string values
+                # string values
+                new_value = new_value.astype(str)
+                new_str_vals = len(np.unique(new_value))*np.ones(np.shape(new_value),
+                                    dtype=self.arr_dtype)
+                new_str_vals = self._str_2_val(new_str_vals, new_value, key_idx)
+                if self.array.shape == (0,0):
+                    # if empty array, start from scratch
+                    self.array = np.reshape(new_str_vals, [1, -1])
+                else:
+                    # if array is not empty, add to it
+                    self.array = np.vstack((self.array, np.reshape(new_str_vals, [1, -1])))
+                self.map[key_idx] = self.shape[0]-1
+            else:
+                # numeric values
+                if not isinstance(new_value, int) \
+                and not isinstance(new_value, float) \
+                and new_value.size > 0:
+                    assert not isinstance(np.asarray(new_value).item(0), str), \
+                            "Cannot set a row with list of strings, \
+                            please use np.ndarray with dtype=object"
+                # Adding numeric values
+                self.str_map[key_idx] = {}
+                if self.array.shape == (0,0):
+                    # if empty array, start from scratch
+                    self.array = np.reshape(new_value, (1,-1))
+                    # have to explicitly convert to float in case
+                    # numbers were interpretted as integers
+                    self.array = self.array.astype(self.arr_dtype)
+                else:
+                    # if array is not empty, add to it
+                    self.array = np.vstack((self.array, np.empty([1, len(self)])))
+                    self.array[-1, :] = np.reshape(new_value, -1)
+                self.map[key_idx] = self.shape[0]-1
+        else:
+            # Updating existing rows or columns
+            rows, cols = self._parse_key_idx(key_idx)
+            row_list, row_str = self._get_set_str_rows(rows,new_value)
+            assert np.all(row_str) or np.all(np.logical_not(row_str)), \
+                "Cannot assign/return combination of strings and numbers"
+            if np.all(row_str):
+                assert isinstance(new_value, np.ndarray) \
+                   and (new_value.dtype in (object,str) \
+                     or np.issubdtype(new_value.dtype,np.dtype('U'))), \
+                        "String assignment only supported for ndarray of type object"
+                inv_map = self.inv_map
+                new_value = np.atleast_2d(new_value)
+                new_str_vals = np.ones_like(new_value, dtype=self.arr_dtype)
+                for row_num, row in enumerate(row_list):
+                    key = inv_map[row]
+                    new_value_row = new_value[row_num , :]
+                    new_str_vals_row = new_str_vals[row_num, :]
+                    new_str_vals[row_num, :] = self._str_2_val(new_str_vals_row,
+                                                    new_value_row, key)
+                self.array[rows, cols] = new_str_vals
+            else:
+                if not isinstance(new_value, int):
+                    assert not isinstance(np.asarray(new_value)[0], str), \
+                            "Please use dtype=object for string assignments"
+                self.array[rows, cols] = new_value
+
+    def __iter__(self):
+        """Initialize iterator over NavData (iterates over all columns)
+
+        Returns
+        -------
+        self: gnss_lib_py.parsers.NavData
+            Instantiation of NavData class with iteration initialized
+        """
+        self.curr_col = 0
+        self.num_cols = np.shape(self.array)[1]
+        return self
+
+    def __next__(self):
+        """Method to get next item when iterating over NavData class
+
+        Returns
+        -------
+        x_curr : gnss_lib_py.parsers.NavData
+            Current column (based on iteration count)
+        """
+        if self.curr_col >= self.num_cols:
+            raise StopIteration
+        x_curr = self.copy(rows=None, cols=self.curr_col)
+        self.curr_col += 1
+        return x_curr
+
+    def __str__(self):
+        str_out = str(self.pandas_df())
+        str_out = str_out.replace("DataFrame","NavData")
+        str_out = str_out.replace("Columns","Rows")
+        # swap rows and columns when printing for NavData consistency
+        str_out = re.sub(r"(.*)\[(\d+)\srows\sx\s(\d+)\scolumns\](.*)",
+                         r'\g<1>[\g<3> rows x \g<2> columns]\g<4>',
+                         str_out)
+        return str_out
+
+    def __len__(self):
+        """Return length of class
+
+        Returns
+        -------
+        length : int
+            Number of time steps in NavData
+        """
+        length = np.shape(self.array)[1]
+        return length
+
+    def _build_navdata(self):
+        """Build attributes for NavData.
+
+        """
+        self.array = np.zeros((0,0), dtype=self.arr_dtype)
+
+    def _get_str_rows(self, rows):
+        """Checks which input rows contain string elements
+
+        Parameters
+        ----------
+        rows : slice/list
+            Rows to check for string elements
+
+        Returns
+        -------
+        row_list : list
+            Input rows, strictly in list format
+        row_str : list
+            List of boolean values indicating which rows contain strings
+        """
+        _row_idx_str_bool = self._row_idx_str_bool
+        if isinstance(rows, slice):
+            slice_idx = rows.indices(self.shape[0])
+            row_list = np.arange(slice_idx[0], slice_idx[1], slice_idx[2])
+            row_str = [_row_idx_str_bool[row] for row in row_list]
+        else:
+            row_list = list(rows)
+            row_str = [_row_idx_str_bool[row] for row in rows]
+        return row_list, row_str
+
+    def _get_set_str_rows(self, rows, new_value):
+        """Checks which output rows contain string elements given input.
+
+        If the row used to be string values but now is numeric, this
+        function also empties the corresponding dictionary in str_map.
+
+        Parameters
+        ----------
+        rows : slice/list
+            Rows to check for string elements
+        new_value : np.ndarray/list/int
+            Values to be added to self.array attribute
+
+        Returns
+        -------
+        row_list : list
+            Input rows, strictly in list format
+        row_str_new : list
+            List of boolean values indicating which of the new rows
+            contain strings.
+        """
+
+        row_list, row_str_existing = self._get_str_rows(rows)
+
+        if isinstance(new_value, np.ndarray) and (new_value.dtype in (object,str) \
+                        or np.issubdtype(new_value.dtype,np.dtype('U'))):
+            if type(new_value.item(0)) in (int, float):
+                row_str_new = [False]*len(row_list)
+            else:
+                row_str_new = [True]*len(row_list)
+        elif isinstance(np.asarray(new_value).item(0), str):
+            raise RuntimeError("Cannot set a row with list of strings, \
+                             please use np.ndarray with dtype=object")
+        else:
+            row_str_new = [False]*len(row_list)
+
+        for row_idx, row in enumerate(row_list):
+            if row_str_existing[row_idx] and not row_str_new[row_idx]:
+                # changed from string to numeric
+                self.str_map[self.inv_map[row]] = {}
+
+        return row_list, row_str_new
+
+    def _str_2_val(self, new_str_vals, new_value, key):
+        """Convert string valued arrays to values for storing in array
+
+        Parameters
+        ----------
+        new_str_vals : np.ndarray
+            Array of dtype=self.arr_dtype where numeric values are to be
+            stored
+        new_value : np.ndarray
+            Array of dtype=object, containing string values that are to
+            be converted
+        key : string
+            Key indicating row where string to numeric conversion is
+            required
+        """
+        if key in self.map:
+            # Key already exists, update existing string value dictionary
+            inv_str_map = {v: k for k, v in self.str_map[key].items()}
+            string_vals = np.unique(new_value)
+            str_map_dict = self.str_map[key]
+            total_str = len(self.str_map[key])
+            for str_val in string_vals:
+                if str_val not in inv_str_map.keys():
+                    str_map_dict[total_str] = str_val
+                    new_str_vals[new_value==str_val] = total_str
+                    total_str += 1
+                else:
+                    new_str_vals[new_value==str_val] = inv_str_map[str_val]
+            self.str_map[key] = str_map_dict
+        else:
+            string_vals = np.unique(new_value)
+            str_dict = dict(enumerate(string_vals))
+            self.str_map[key] = str_dict
+            new_str_vals = len(string_vals)*np.ones(np.shape(new_value),
+                                                   dtype=self.arr_dtype)
+            # Set unassigned value to int not accessed by string map
+            for str_key, str_val in str_dict.items():
+                if new_str_vals.size == 1:
+                    new_str_vals = np.array(str_key,dtype=self.arr_dtype)
+                else:
+                    new_str_vals[new_value==str_val] = str_key
+            # Copy set to false to prevent memory overflows
+            new_str_vals = np.round(new_str_vals.astype(self.arr_dtype,
+                                                        copy=False))
+        return new_str_vals
+
+    def _get_strings(self, key):
+        """Return list of strings for given key
+
+        Parameters
+        ----------
+        key : string for column name required as string
+
+        Returns
+        -------
+        values_str : np.ndarray
+            1D array with string entries corresponding to dataset
+        """
+        values_int = self.array[self.map[key],:].astype(int)
+        values_str = values_int.astype(object, copy=True)
+        # True by default but making explicit for clarity
+        for str_key, str_val in self.str_map[key].items():
+            values_str[values_int==str_key] = str_val
+        return values_str
+
+    def _parse_key_idx(self, key_idx):
+        """Break down input queries to relevant row and column indices
+
+        Parameters
+        ----------
+        key_idx : str/list/tuple/slice/int
+            Query for array items
+
+        Returns
+        -------
+        rows : slice/list
+            Rows to extract from the array
+        cols : slice/list
+            Columns to extract from the array
+        """
+        if isinstance(key_idx, str):
+            rows = [self.map[key_idx]]
+            cols = slice(None, None)
+        elif isinstance(key_idx, list) and isinstance(key_idx[0], str):
+            rows = [self.map[k] for k in key_idx]
+            cols = slice(None, None)
+        elif isinstance(key_idx, slice):
+            rows = key_idx
+            cols = slice(None, None)
+        elif isinstance(key_idx, int):
+            rows = [key_idx]
+            cols = slice(None, None)
+        else:
+            if isinstance(key_idx[1], int):
+                cols = [key_idx[1]]
+            else:
+                cols = key_idx[1]
+
+            rows = []
+            if isinstance(key_idx[0], slice):
+                rows = key_idx[0]
+            elif isinstance(key_idx[0], int):
+                rows = [key_idx[0]]
+            else:
+                if not isinstance(key_idx[0],list):
+                    row_key = [key_idx[0]]
+                else:
+                    row_key = key_idx[0]
+                for key in row_key:
+                    rows.append(self.map[key])
+        return rows, cols
+
+    @staticmethod
+    def _row_map():
+        """Map of column names from loaded to gnss_lib_py standard
+
+        Initializes as an emptry dictionary, must be reimplemented for
+        custom parsers.
+
+        Returns
+        -------
+        row_map : Dict
+            Dictionary of the form {old_name : new_name}
+        """
+
+        row_map = {}
+
+        return row_map

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -485,10 +485,11 @@ class NavData():
         numpy_array : np.ndarray
             Array containing only numeric data to add
         """
+        old_row_num = len(self.map)
         old_len = len(self)
         new_data_cols = slice(old_len, None)
         if numpy_array is not None:
-            if old_len == 0:
+            if old_row_num == 0:
                 self.from_numpy_array(numpy_array)
             else:
                 if len(numpy_array.shape)==1:
@@ -497,15 +498,14 @@ class NavData():
                                         dtype=self.arr_dtype)))
                 self[:, new_data_cols] = numpy_array
         if csv_path is not None:
-            if old_len == 0:
+            if old_row_num == 0:
                 self.from_csv_path(csv_path)
             else:
                 pandas_df = pd.read_csv(csv_path)
         if pandas_df is not None:
-            if old_len == 0:
+            if old_row_num == 0:
                 self.from_pandas_df(pandas_df)
             else:
-
                 self.array = np.hstack((self.array, np.empty(pandas_df.shape).T))
                 for col in pandas_df.columns:
                     self[col, new_data_cols] = np.asarray(pandas_df[col].values)

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -349,6 +349,13 @@ class NavData():
     def __setitem__(self, key_idx, new_value):
         """Add/update rows.
 
+        __setitem__ expects that the shape of the value being passed
+        matches the shape of the internal arrays that have to be set.
+        So, if 2 variable types (rows) at 10 instances (columns) need to
+        be set, the input new_value must be of shape (2, 10).
+        If the shape is (10, 2) the assignment operator will raise a
+        ValueError. This applies to all types of value assignments.
+
         Parameters
         ----------
         key_idx : str/list/tuple/slice/int

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -811,8 +811,7 @@ class NavData():
             for row in remap_rows:
                 new_row_values = list(self[row])
                 for old_value, new_value in mapper.items():
-                    while old_value in new_row_values:
-                        new_row_values[new_row_values.index(old_value)] = new_value
+                    new_row_values = [new_value if v == old_value else v for v in new_row_values]
                 if inplace:
                     self[row] = np.array(new_row_values)
                 else:

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -411,7 +411,8 @@ class NavData():
                      or np.issubdtype(new_value.dtype,np.dtype('U'))), \
                         "String assignment only supported for ndarray of type object"
                 inv_map = self.inv_map
-                new_value = np.reshape(new_value, [-1, new_value.shape[0]])
+                new_value = np.atleast_2d(new_value)
+                # new_value = np.reshape(new_value, [-1, new_value.shape[0]])
                 new_str_vals = np.ones_like(new_value, dtype=self.arr_dtype)
                 for row_num, row in enumerate(row_list):
                     key = inv_map[row]

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -29,7 +29,7 @@ class NavData():
         Map is of the form {pandas column name : {}} for non string rows.
     """
     def __init__(self, csv_path=None, pandas_df=None, numpy_array=None,
-                 header="infer"):
+                 **kwargs):
         # For a Pythonic implementation,
         # including all attributes as None in the beginning
         self.arr_dtype = np.float32 # default value
@@ -43,7 +43,7 @@ class NavData():
         self.num_cols = 0
 
         if csv_path is not None:
-            self.from_csv_path(csv_path, header)
+            self.from_csv_path(csv_path, **kwargs)
         elif pandas_df is not None:
             self.from_pandas_df(pandas_df)
         elif numpy_array is not None:
@@ -65,7 +65,7 @@ class NavData():
         """
         self.array = np.zeros((0,0), dtype=self.arr_dtype)
 
-    def from_csv_path(self, csv_path, header="infer"):
+    def from_csv_path(self, csv_path, **kwargs):
         """Build attributes of NavData using csv file.
 
         Parameters
@@ -75,6 +75,8 @@ class NavData():
         header : string, int, or None
             "infer" uses the first row as column names, setting to
             None will add int names for the columns.
+        sep : char
+            Delimiter to use when reading in csv file.
 
         """
         if not isinstance(csv_path, str):
@@ -84,7 +86,7 @@ class NavData():
 
         self.build_navdata()
 
-        pandas_df = pd.read_csv(csv_path, header=header)
+        pandas_df = pd.read_csv(csv_path, **kwargs)
         self.from_pandas_df(pandas_df)
 
     def from_pandas_df(self, pandas_df):

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -665,6 +665,8 @@ class NavData():
 
     def __str__(self):
         str_out = str(self.pandas_df())
+        str_out = str_out.replace("DataFrame","NavData")
+        str_out = str_out.replace("Columns","Rows")
         return str_out
 
     def __len__(self):

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -108,8 +108,8 @@ class NavData():
         self.build_navdata()
 
         for _, col_name in enumerate(pandas_df.columns):
-            newvalue = pandas_df[col_name].to_numpy()
-            self[col_name] = newvalue
+            new_value = pandas_df[col_name].to_numpy()
+            self[col_name] = new_value
 
     def from_numpy_array(self, numpy_array):
         """Build attributes of NavData using np.ndarray.
@@ -302,16 +302,16 @@ class NavData():
 
         return arr_slice
 
-    def __setitem__(self, key_idx, newvalue):
+    def __setitem__(self, key_idx, new_value):
         """Add/update rows.
 
         Parameters
         ----------
         key_idx : str/list/tuple/slice/int
             Query for array items to set
-
-        newvalue : np.ndarray/list/int
+        new_value : np.ndarray/list/int
             Values to be added to self.array attribute
+
         """
         if isinstance(key_idx, int) and len(self.map)<=key_idx:
             raise KeyError('Row indices must be strings when assigning new values')
@@ -319,13 +319,13 @@ class NavData():
             raise KeyError('Row indices must be strings when assigning new values')
         if isinstance(key_idx, str) and key_idx not in self.map.keys():
             #Creating an entire new row
-            if isinstance(newvalue, np.ndarray) and newvalue.dtype==object:
+            if isinstance(new_value, np.ndarray) and new_value.dtype==object:
                 # Adding string values
-                # print("\n",key_idx,"\n",newvalue)
-                self.fillna(newvalue)
-                new_str_vals = len(np.unique(newvalue))*np.ones(np.shape(newvalue),
+                # print("\n",key_idx,"\n",new_value)
+                self.fillna(new_value)
+                new_str_vals = len(np.unique(new_value))*np.ones(np.shape(new_value),
                                     dtype=self.arr_dtype)
-                new_str_vals = self._str_2_val(new_str_vals, newvalue, key_idx)
+                new_str_vals = self._str_2_val(new_str_vals, new_value, key_idx)
                 if self.array.shape == (0,0):
                     # if empty array, start from scratch
                     self.array = np.reshape(new_str_vals, [1, -1])
@@ -334,22 +334,22 @@ class NavData():
                     self.array = np.vstack((self.array, np.reshape(new_str_vals, [1, -1])))
                 self.map[key_idx] = self.shape[0]-1
             else:
-                # print("\n",key_idx,"\n")#,newvalue)
-                if not isinstance(newvalue, int) and not isinstance(newvalue, float):
-                    assert not isinstance(np.asarray(newvalue).item(0), str), \
+                # print("\n",key_idx,"\n")#,new_value)
+                if not isinstance(new_value, int) and not isinstance(new_value, float):
+                    assert not isinstance(np.asarray(new_value).item(0), str), \
                             "Cannot set a row with list of strings, please use np.ndarray with dtype=object"
                 # Adding numeric values
                 self.str_map[key_idx] = {}
                 if self.array.shape == (0,0):
                     # if empty array, start from scratch
-                    self.array = np.reshape(newvalue, (1,-1))
+                    self.array = np.reshape(new_value, (1,-1))
                     # have to explicitly convert to float in case
                     # numbers were interpretted as integers
                     self.array = self.array.astype(self.arr_dtype)
                 else:
                     # if array is not empty, add to it
                     self.array = np.vstack((self.array, np.empty([1, len(self)])))
-                    self.array[-1, :] = np.reshape(newvalue, -1)
+                    self.array[-1, :] = np.reshape(new_value, -1)
                 self.map[key_idx] = self.shape[0]-1
         else:
             # Updating existing rows or columns
@@ -358,26 +358,26 @@ class NavData():
             assert np.all(row_str) or np.all(np.logical_not(row_str)), \
                 "Cannot assign/return combination of strings and numbers"
             if np.all(row_str):
-                assert isinstance(newvalue, np.ndarray) and newvalue.dtype==object, \
+                assert isinstance(new_value, np.ndarray) and new_value.dtype==object, \
                         "String assignment only supported for ndarray of type object"
                 inv_map = self.inv_map
-                newvalue = np.reshape(newvalue, [-1, newvalue.shape[0]])
-                new_str_vals = np.ones_like(newvalue, dtype=self.arr_dtype)
+                new_value = np.reshape(new_value, [-1, new_value.shape[0]])
+                new_str_vals = np.ones_like(new_value, dtype=self.arr_dtype)
                 for row_num, row in enumerate(row_list):
                     # print('Assigning values to ', inv_map[row])
                     key = inv_map[row]
-                    newvalue_row = newvalue[row_num , :]
+                    new_value_row = new_value[row_num , :]
                     new_str_vals_row = new_str_vals[row_num, :]
                     new_str_vals[row_num, :] = self._str_2_val(new_str_vals_row,
-                                                    newvalue_row, key)
+                                                    new_value_row, key)
                 self.array[rows, cols] = new_str_vals
             else:
-                if not isinstance(newvalue, int):
-                    assert not isinstance(np.asarray(newvalue)[0], str), \
+                if not isinstance(new_value, int):
+                    assert not isinstance(np.asarray(new_value)[0], str), \
                             "Please use dtype=object for string assignments"
-                self.array[rows, cols] = newvalue
+                self.array[rows, cols] = new_value
 
-    def _str_2_val(self, new_str_vals, newvalue, key):
+    def _str_2_val(self, new_str_vals, new_value, key):
         """Convert string valued arrays to values for storing in array
 
         Parameters
@@ -385,7 +385,7 @@ class NavData():
         new_str_vals : np.ndarray
             Array of dtype=self.arr_dtype where numeric values are to be
             stored
-        newvalue : np.ndarray
+        new_value : np.ndarray
             Array of dtype=object, containing string values that are to
             be converted
         key : string
@@ -395,29 +395,29 @@ class NavData():
         if key in self.map.keys():
             # Key already exists, update existing string value dictionary
             inv_str_map = {v: k for k, v in self.str_map[key].items()}
-            string_vals = np.unique(newvalue)
+            string_vals = np.unique(new_value)
             str_map_dict = self.str_map[key]
             total_str = len(self.str_map[key])
             for str_val in string_vals:
                 if str_val not in inv_str_map.keys():
                     str_map_dict[total_str] = str_val
-                    new_str_vals[newvalue==str_val] = total_str
+                    new_str_vals[new_value==str_val] = total_str
                     total_str += 1
                 else:
-                    new_str_vals[newvalue==str_val] = inv_str_map[str_val]
+                    new_str_vals[new_value==str_val] = inv_str_map[str_val]
             self.str_map[key] = str_map_dict
         else:
-            string_vals = np.unique(newvalue)
+            string_vals = np.unique(new_value)
             str_dict = dict(enumerate(string_vals))
             self.str_map[key] = str_dict
-            new_str_vals = len(string_vals)*np.ones(np.shape(newvalue),
+            new_str_vals = len(string_vals)*np.ones(np.shape(new_value),
                                                    dtype=self.arr_dtype)
             # Set unassigned value to int not accessed by string map
             for str_key, str_val in str_dict.items():
                 if new_str_vals.size == 1:
                     new_str_vals = np.array(str_key,dtype=self.arr_dtype)
                 else:
-                    new_str_vals[newvalue==str_val] = str_key
+                    new_str_vals[new_value==str_val] = str_key
             # Copy set to false to prevent memory overflows
             new_str_vals = np.round(new_str_vals.astype(self.arr_dtype,
                                                         copy=False))

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -50,7 +50,7 @@ class NavData():
         elif numpy_array is not None:
             self.from_numpy_array(numpy_array)
         else:
-            self.build_navdata()
+            self._build_navdata()
 
         self.rename(self._row_map(), inplace=True)
 
@@ -60,7 +60,7 @@ class NavData():
         """Postprocess loaded data. Optional in subclass
         """
 
-    def build_navdata(self):
+    def _build_navdata(self):
         """Build attributes for NavData.
 
         """
@@ -85,7 +85,7 @@ class NavData():
         if not os.path.exists(csv_path):
             raise OSError("file not found")
 
-        self.build_navdata()
+        self._build_navdata()
 
         pandas_df = pd.read_csv(csv_path, **kwargs)
         self.from_pandas_df(pandas_df)
@@ -106,7 +106,7 @@ class NavData():
             # class they need to be strings
             pandas_df.rename(str, axis="columns", inplace=True)
 
-        self.build_navdata()
+        self._build_navdata()
 
         for _, col_name in enumerate(pandas_df.columns):
             new_value = pandas_df[col_name].to_numpy()
@@ -125,7 +125,7 @@ class NavData():
         if not isinstance(numpy_array, np.ndarray):
             raise TypeError("numpy_array must be np.ndarray")
 
-        self.build_navdata()
+        self._build_navdata()
 
         for row_num in range(numpy_array.shape[0]):
             self[str(row_num)] = numpy_array[row_num,:]
@@ -309,7 +309,6 @@ class NavData():
             if row_str_existing[row_idx] and not row_str_new[row_idx]:
                 # changed from string to numeric
                 self.str_map[self.inv_map[row]] = {}
-
 
         return row_list, row_str_new
 

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -154,15 +154,16 @@ class NavData():
         df : pd.DataFrame
             DataFrame with data, including strings as strings
         """
+
         df_list = []
-        for key, value in self.str_map.items():
-            if value:
-                vect_val = self.get_strings(key)
-            else:
-                vect_val = self.array[self.map[key], :]
-            df_val = pd.DataFrame(vect_val, columns=[key])
-            df_list.append(df_val)
-        dframe = pd.concat(df_list, axis=1)
+        for row in self.rows:
+            df_list.append(np.atleast_1d(self[row]))
+
+        # transpose list to conform to Pandas input
+        df_list = [list(x) for x in zip(*df_list)]
+
+        dframe = pd.DataFrame(df_list,columns=self.rows)
+
         return dframe
 
     def get_strings(self, key):

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -380,7 +380,9 @@ class NavData():
                 self.map[key_idx] = self.shape[0]-1
             else:
                 # numeric values
-                if not isinstance(new_value, int) and not isinstance(new_value, float):
+                if not isinstance(new_value, int) \
+                and not isinstance(new_value, float) \
+                and new_value.size > 0:
                     assert not isinstance(np.asarray(new_value).item(0), str), \
                             "Cannot set a row with list of strings, \
                             please use np.ndarray with dtype=object"

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -6,6 +6,7 @@ __authors__ = "Ashwin Kanhere, D. Knowles"
 __date__ = "03 Nov 2021"
 
 import os
+import re
 import copy
 
 import numpy as np
@@ -664,6 +665,10 @@ class NavData():
         str_out = str(self.pandas_df())
         str_out = str_out.replace("DataFrame","NavData")
         str_out = str_out.replace("Columns","Rows")
+        # swap rows and columns when printing for NavData consistency
+        str_out = re.sub(r"(.*)\[(\d+)\srows\sx\s(\d+)\scolumns\](.*)",
+                         r'\g<1>[\g<3> rows x \g<2> columns]\g<4>',
+                         str_out)
         return str_out
 
     def __len__(self):

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -806,9 +806,9 @@ class NavData():
 
         Parameters
         ----------
-        rows : None/list/np.ndarray
+        rows : None/list/np.ndarray/tuple
             Rows to remove from NavData
-        cols : None/list/np.ndarray
+        cols : None/list/np.ndarray/tuple
             Columns to remove from NavData
 
         Returns
@@ -836,3 +836,32 @@ class NavData():
             key = row_idx
             new_navdata[key] = new_row
         return new_navdata
+
+    def in_rows(self, rows):
+        """Checks whether the given rows are in NavData.
+
+        If the rows are not in NavData, it creates a KeyError and lists
+        all non-existent rows.
+
+        Parameters
+        ----------
+        rows : string or list/np.ndarray/tuple of strings
+            Indexes to check whether they are rows in NavData
+        """
+
+        if isinstance(rows,str):
+            if rows not in self.rows:
+                missing_rows = [rows]
+            else:
+                missing_rows = []
+        elif type(rows) in (list, np.ndarray, tuple):
+            if isinstance(rows,np.ndarray):
+                rows = np.atleast_1d(rows)
+            missing_rows = ["'"+row+"'" for row in rows if row not in self.rows]
+        else:
+            raise KeyError("input to in_rows must be a single row " \
+                         + "index or list/np.ndarray/tuple of indexes")
+
+        if len(missing_rows) > 0:
+            raise KeyError(", ".join(missing_rows) + " row(s) are" \
+                           + " missing from NavData object.")

--- a/gnss_lib_py/utils/visualizations.py
+++ b/gnss_lib_py/utils/visualizations.py
@@ -291,22 +291,9 @@ def plot_skyplot(navdata, state_estimate, save=True, prefix=""):
 
     if not isinstance(prefix, str):
         raise TypeError("Prefix must be a string.")
-    if "signal_type" not in navdata.rows:
-        raise KeyError("signal_type missing")
-    if "sv_id" not in navdata.rows:
-        raise KeyError("sv_id missing")
-    if "x_sv_m" not in navdata.rows:
-        raise KeyError("x_sv_m missing")
-    if "y_sv_m" not in navdata.rows:
-        raise KeyError("y_sv_m missing")
-    if "z_sv_m" not in navdata.rows:
-        raise KeyError("z_sv_m missing")
-    if "x_rx_m" not in state_estimate.rows:
-        raise KeyError("x_rx_m missing")
-    if "y_rx_m" not in state_estimate.rows:
-        raise KeyError("y_rx_m missing")
-    if "z_rx_m" not in state_estimate.rows:
-        raise KeyError("z_rx_m missing")
+    # check for missing rows
+    navdata.in_rows(["signal_type","sv_id","x_sv_m","y_sv_m","z_sv_m"])
+    state_estimate.in_rows(["x_rx_m","y_rx_m","z_rx_m"])
 
     local_coord = None
 
@@ -432,10 +419,8 @@ def plot_residuals(navdata, save=True, prefix=""):
         raise KeyError("residuals missing, run solve_residuals().")
     if not isinstance(prefix, str):
         raise TypeError("Prefix must be a string.")
-    if "signal_type" not in navdata.rows:
-        raise KeyError("signal_type missing")
-    if "sv_id" not in navdata.rows:
-        raise KeyError("sv_id missing")
+    # check for missing rows
+    navdata.in_rows(["signal_type","sv_id"])
     if save: # pragma: no cover
         root_path = os.path.dirname(
                     os.path.dirname(

--- a/gnss_lib_py/utils/visualizations.py
+++ b/gnss_lib_py/utils/visualizations.py
@@ -212,8 +212,8 @@ def plot_metric_by_constellation(navdata, metric, save=True, prefix=""):
 
     data = {}
 
-    signal_types = navdata.get_strings("signal_type")
-    sv_ids = navdata.get_strings("sv_id")
+    signal_types = navdata._get_strings("signal_type")
+    sv_ids = navdata._get_strings("sv_id")
 
     time0 = navdata["gps_millis",0]/1000.
 
@@ -298,8 +298,8 @@ def plot_skyplot(navdata, state_estimate, save=True, prefix=""):
     local_coord = None
 
     skyplot_data = {}
-    signal_types = list(navdata.get_strings("signal_type"))
-    sv_ids = navdata.get_strings("sv_id")
+    signal_types = list(navdata._get_strings("signal_type"))
+    sv_ids = navdata._get_strings("sv_id")
 
     pos_sv_m = np.hstack((navdata["x_sv_m",:].reshape(-1,1),
                           navdata["y_sv_m",:].reshape(-1,1),
@@ -432,8 +432,8 @@ def plot_residuals(navdata, save=True, prefix=""):
         figs = []
 
     residual_data = {}
-    signal_types = navdata.get_strings("signal_type")
-    sv_ids = navdata.get_strings("sv_id")
+    signal_types = navdata._get_strings("signal_type")
+    sv_ids = navdata._get_strings("sv_id")
 
     time0 = navdata["gps_millis",0]/1000.
 

--- a/notebooks/tutorials/algorithms.ipynb
+++ b/notebooks/tutorials/algorithms.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "# load Android Google Challenge data\n",
-    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
+    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/android_2021/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
     "derived_data = AndroidDerived2021(\"Pixel4XL_derived.csv\", remove_timing_outliers=False)"
    ]
   },

--- a/notebooks/tutorials/parsers.ipynb
+++ b/notebooks/tutorials/parsers.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "# download Android data file\n",
-    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
+    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/android_2021/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
     "# load Android Google Challenge data\n",
     "derived_data = AndroidDerived2021(\"Pixel4XL_derived.csv\", remove_timing_outliers=False)"
    ]

--- a/notebooks/tutorials/utilities.ipynb
+++ b/notebooks/tutorials/utilities.ipynb
@@ -95,7 +95,7 @@
     "from gnss_lib_py.utils.file_operations import get_lib_dir\n",
     "\n",
     "# load Android Google Challenge data\n",
-    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
+    "!wget https://raw.githubusercontent.com/Stanford-NavLab/gnss_lib_py/main/data/unit_test/android_2021/Pixel4XL_derived.csv --quiet -O \"Pixel4XL_derived.csv\"\n",
     "derived_data = AndroidDerived2021(\"Pixel4XL_derived.csv\", remove_timing_outliers=False)"
    ]
   },

--- a/tests/parsers/test_android.py
+++ b/tests/parsers/test_android.py
@@ -64,6 +64,38 @@ def fixture_derived_path(root_path):
     derived_path = os.path.join(root_path, 'Pixel4_derived.csv')
     return derived_path
 
+@pytest.fixture(name="derived_path_xl")
+def fixture_derived_path_xl(root_path):
+    """Filepath of Android Derived measurements
+
+    Parameters
+    ----------
+    root_path : string
+        Path of testing dataset root path
+
+    Returns
+    -------
+    derived_path : string
+        Location for the unit_test Android derived measurements
+
+    Notes
+    -----
+    Test data is a subset of the Android Raw Measurement Dataset [1]_,
+    particularly the train/2020-05-14-US-MTV-1/Pixel4 trace. The dataset
+    was retrieved from
+    https://www.kaggle.com/c/google-smartphone-decimeter-challenge/data
+
+    References
+    ----------
+    .. [1] Fu, Guoyu Michael, Mohammed Khider, and Frank van Diggelen.
+        "Android Raw GNSS Measurement Datasets for Precise Positioning."
+        Proceedings of the 33rd International Technical Meeting of the
+        Satellite Division of The Institute of Navigation (ION GNSS+
+        2020). 2020.
+    """
+    derived_path = os.path.join(root_path, 'Pixel4XL_derived.csv')
+    return derived_path
+
 
 @pytest.fixture(name="android_raw_path")
 def fixture_raw_path(root_path):
@@ -525,3 +557,19 @@ def test_gt_alt_nan(root_path_2022):
         gt_2022 = android.AndroidGroundTruth2022(gt_2022_nan)
         np.testing.assert_almost_equal(gt_2022['alt_gt_m'],
                                        np.zeros(len(gt_2022)))
+
+def test_remove_all_data(derived_path_xl):
+    """Test what happens when remove_timing_outliers removes all data.
+
+    Parameters
+    ----------
+    derived_path : string
+        Location for the unit_test Android 2021 derived measurements.
+
+    """
+    # Also tests if strings are being converted back correctly
+    with pytest.warns(RuntimeWarning):
+        derived = android.AndroidDerived2021(derived_path_xl,
+                                   remove_timing_outliers=True)
+
+    assert derived.shape == (21,0)

--- a/tests/parsers/test_android.py
+++ b/tests/parsers/test_android.py
@@ -80,14 +80,14 @@ def fixture_derived_path_xl(root_path):
 
     Notes
     -----
-    Test data is a subset of the Android Raw Measurement Dataset [1]_,
-    particularly the train/2020-05-14-US-MTV-1/Pixel4 trace. The dataset
-    was retrieved from
+    Test data is a subset of the Android Raw Measurement Dataset [6]_,
+    particularly the train/2020-05-14-US-MTV-1/Pixel4XL trace. The
+    dataset was retrieved from
     https://www.kaggle.com/c/google-smartphone-decimeter-challenge/data
 
     References
     ----------
-    .. [1] Fu, Guoyu Michael, Mohammed Khider, and Frank van Diggelen.
+    .. [6] Fu, Guoyu Michael, Mohammed Khider, and Frank van Diggelen.
         "Android Raw GNSS Measurement Datasets for Precise Positioning."
         Proceedings of the 33rd International Technical Meeting of the
         Satellite Division of The Institute of Navigation (ION GNSS+

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -7,9 +7,9 @@ __date__ = "30 Apr 2022"
 
 
 import os
+import itertools
 
 import pytest
-import itertools
 import numpy as np
 import pandas as pd
 from pytest_lazyfixture import lazy_fixture

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -83,6 +83,13 @@ def fixture_csv_int_first():
     """
     return fixture_csv_path("navdata_test_int_first.csv")
 
+@pytest.fixture(name="csv_only_header")
+def fixture_csv_only_header():
+    """csv where there's no data, only columns.
+
+    """
+    return fixture_csv_path("navdata_only_header.csv")
+
 def load_test_dataframe(csv_filepath, header="infer"):
     """Create dataframe test fixture.
 
@@ -314,6 +321,32 @@ def test_init_np(numpy_array):
     # raises exception if input pandas dataframe
     with pytest.raises(TypeError):
         data = NavData(numpy_array=pd.DataFrame([0]))
+
+def test_init_only_header(csv_only_header, csv_simple):
+    """Test initializing NavData class with csv with only header
+
+    Parameters
+    ----------
+    csv_only_header : string
+        Path to csv file containing headers, but no data
+    csv_simple : string
+        Path to csv file headers and data
+
+    """
+
+    # should work when csv is passed
+    csv_data = NavData(csv_path=csv_only_header)
+    assert csv_data.shape == (4,0)
+    # test adding new data to empty NavData with column names
+    csv_data.add(csv_path=csv_simple)
+    assert csv_data.shape == (4,6)
+
+    # should work when DataFrame is passed
+    pd_data = NavData(pandas_df=pd.read_csv(csv_only_header))
+    assert pd_data.shape == (4,0)
+    # test adding new data to empty NavData with column names
+    pd_data.add(pandas_df=pd.read_csv(csv_only_header))
+    assert pd_data.shape == (4,6)
 
 @pytest.mark.parametrize('pandas_df',
                         [
@@ -1039,7 +1072,7 @@ def test_remove_navdata(data, df_simple, rows, cols):
                 expect_fail = True
                 expect_message = str(col)
                 break
-    
+
     if expect_fail:
         with pytest.raises(KeyError) as excinfo:
             new_data = data.remove(rows=rows, cols=cols)

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -650,6 +650,54 @@ def test_set_get_item(data, index, new_value, exp_value):
     data[index] = new_value
     np.testing.assert_array_equal(data[index], np.squeeze(exp_value))
 
+def test_multi_set(data,new_string):
+    """Test setting a numeric row with strings and vice versa.
+
+    Parameters
+    ----------
+    data : gnss_lib_py.parsers.navdata.NavData
+        NavData instance for testing
+    new_string : np.ndarray
+        String of length 6 to test string assignment
+
+    """
+    new_numeric = np.arange(len(data),dtype=float)
+    data_temp1 = data.copy()
+
+    # test numerics with input of size (2,6)
+    double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
+                                      new_numeric.reshape(1,-1)))
+    data_temp1[["integers","floats"]] = double_numeric_input
+
+    np.testing.assert_array_equal(data_temp1["integers"], new_numeric)
+    np.testing.assert_array_equal(data_temp1["floats"], new_numeric)
+
+    # test strings with input of size (2,6)
+    double_string_input = np.vstack((new_string.reshape(1,-1),
+                                     new_string.reshape(1,-1)))
+    data_temp1[["strings","names"]] = double_string_input
+
+    np.testing.assert_array_equal(data_temp1["strings"], new_string)
+    np.testing.assert_array_equal(data_temp1["names"], new_string)
+
+    data_temp2 = data.copy()
+
+    # test numerics with input of size (6,2)
+    double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
+                                      new_numeric.reshape(1,-1))).T
+    data_temp2[["integers","floats"]] = double_numeric_input
+
+    np.testing.assert_array_equal(data_temp2["integers"], new_numeric)
+    np.testing.assert_array_equal(data_temp2["floats"], new_numeric)
+
+    # test strings with input of size (6,2)
+    double_string_input = np.vstack((new_string.reshape(1,-1),
+                                     new_string.reshape(1,-1))).T
+    data_temp2[["strings","names"]] = double_string_input
+
+    np.testing.assert_array_equal(data_temp2["strings"], new_string)
+    np.testing.assert_array_equal(data_temp2["names"], new_string)
+
 @pytest.mark.parametrize("row_idx",
                         [slice(7, 8),
                         8])

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -1667,6 +1667,14 @@ def test_str_navdata(df_simple, df_only_header):
     df_str = df_str.replace("Columns","Rows")
     assert navdata_str==df_str
 
+    # test DataFrame with a single row of data
+    df_long = pd.DataFrame(np.zeros((200,4)),
+                                    columns=["A","B","C","D"])
+    navdata = NavData(pandas_df=df_long)
+    assert str(navdata) == str(df_long).replace("[200 rows x 4 columns]",
+                                                "[4 rows x 200 columns]")
+
+
 def test_in_rows_single(data):
     """Test the in_rows function.
 

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -148,6 +148,13 @@ def fixture_df_int_first(csv_int_first):
     """
     return load_test_dataframe(csv_int_first)
 
+@pytest.fixture(name='df_only_header')
+def fixture_df_only_header(csv_only_header):
+    """df where only headers given and no data.
+
+    """
+    return load_test_dataframe(csv_only_header)
+
 @pytest.fixture(name="data")
 def load_test_navdata(df_simple):
     """Creates a NavData instance from df_simple.
@@ -1716,3 +1723,40 @@ def test_in_rows_multi(data):
                 data_temp.in_rows(combo_rows)
             for row in combo_rows:
                 assert row in str(excinfo.value)
+
+def test_pandas_df(df_simple, df_only_header):
+    """Test that the NavData class can be printed without errors
+
+    Parameters
+    ----------
+    df_simple : pd.DataFrame
+        Dataframe with which to construct NavData instance
+    df_only_header : pd.DataFrame
+        Dataframe with only column names and no data
+    """
+    navdata = NavData(pandas_df=df_simple)
+
+    # test simple DataFrame
+    pd.testing.assert_frame_equal(navdata.pandas_df().sort_index(axis=1),
+                                  df_simple.sort_index(axis=1),
+                                  check_names=True, check_dtype=False)
+
+    # test DataFrame with a single row of data
+    df_super_simple = pd.DataFrame([["first",1.,3,"fourth"]],
+                                    columns=["A","B","C","D"])
+    navdata = NavData(pandas_df=df_super_simple)
+    pd.testing.assert_frame_equal(navdata.pandas_df().sort_index(axis=1),
+                                  df_super_simple.sort_index(axis=1),
+                                  check_names=True, check_dtype=False)
+
+    # make sure print doesn't break if given only headers
+    navdata = NavData(pandas_df=df_only_header)
+    pd.testing.assert_frame_equal(navdata.pandas_df().sort_index(axis=1),
+                                  df_only_header.sort_index(axis=1),
+                                  check_names=True)
+
+    # make sure it doesn't break with empty NavData
+    navdata = NavData()
+    pd.testing.assert_frame_equal(navdata.pandas_df().sort_index(axis=1),
+                                  pd.DataFrame().sort_index(axis=1),
+                                  check_names=True)

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -345,7 +345,7 @@ def test_init_only_header(csv_only_header, csv_simple):
     pd_data = NavData(pandas_df=pd.read_csv(csv_only_header))
     assert pd_data.shape == (4,0)
     # test adding new data to empty NavData with column names
-    pd_data.add(pandas_df=pd.read_csv(csv_only_header))
+    pd_data.add(pandas_df=pd.read_csv(csv_simple))
     assert pd_data.shape == (4,6)
 
 @pytest.mark.parametrize('pandas_df',
@@ -850,7 +850,7 @@ def test_multi_set_changing_type(data,new_string):
     np.testing.assert_array_equal(data_temp1["integers"], new_string)
     np.testing.assert_array_equal(data_temp1["floats"], new_string)
 
-    data_temp2 = data.copy()    
+    data_temp2 = data.copy()
 
 @pytest.mark.parametrize("row_idx",
                         [slice(7, 8),

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -734,11 +734,11 @@ def test_multi_set(data,new_string):
 
     # test numerics with input of size (2,6)
     double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
-                                      new_numeric.reshape(1,-1)))
+                                        new_numeric.reshape(1,-1) + 10.5))
     data_temp1[["integers","floats"]] = double_numeric_input
 
     np.testing.assert_array_equal(data_temp1["integers"], new_numeric)
-    np.testing.assert_array_equal(data_temp1["floats"], new_numeric)
+    np.testing.assert_array_equal(data_temp1["floats"], new_numeric+10.5)
 
     # test strings with input of size (2,6)
     double_string_input = np.vstack((new_string.reshape(1,-1),
@@ -750,21 +750,26 @@ def test_multi_set(data,new_string):
 
     data_temp2 = data.copy()
 
-    # test numerics with input of size (6,2)
-    double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
-                                      new_numeric.reshape(1,-1))).T
-    data_temp2[["integers","floats"]] = double_numeric_input
+    with pytest.raises(ValueError):
+        # NavData does not expect values with rows and columns
+        # interchanged. Shapes must be set to what the underlying array
+        # expects. This (and the following) test verifies that
+        # test numerics with input of size (6,2)
+        double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
+                                        new_numeric.reshape(1,-1))).T
+        data_temp2[["integers","floats"]] = double_numeric_input
 
-    np.testing.assert_array_equal(data_temp2["integers"], new_numeric)
-    np.testing.assert_array_equal(data_temp2["floats"], new_numeric)
+        np.testing.assert_array_equal(data_temp2["integers"], new_numeric)
+        np.testing.assert_array_equal(data_temp2["floats"], new_numeric)
 
-    # test strings with input of size (6,2)
-    double_string_input = np.vstack((new_string.reshape(1,-1),
-                                     new_string.reshape(1,-1))).T
-    data_temp2[["strings","names"]] = double_string_input
+    with pytest.raises(ValueError):
+        # test strings with input of size (6,2)
+        double_string_input = np.vstack((new_string.reshape(1,-1),
+                                        new_string.reshape(1,-1))).T
+        data_temp2[["strings","names"]] = double_string_input
 
-    np.testing.assert_array_equal(data_temp2["strings"], new_string)
-    np.testing.assert_array_equal(data_temp2["names"], new_string)
+        np.testing.assert_array_equal(data_temp2["strings"], new_string)
+        np.testing.assert_array_equal(data_temp2["names"], new_string)
 
 def test_set_changing_type(data,new_string):
     """Test setting a numeric row with strings and vice versa.
@@ -845,23 +850,7 @@ def test_multi_set_changing_type(data,new_string):
     np.testing.assert_array_equal(data_temp1["integers"], new_string)
     np.testing.assert_array_equal(data_temp1["floats"], new_string)
 
-    data_temp2 = data.copy()
-
-    # test setting strings to numerics with input of size (6,2)
-    double_numeric_input = np.vstack((new_numeric.reshape(1,-1),
-                                      new_numeric.reshape(1,-1))).T
-    data_temp2[["strings","names"]] = double_numeric_input
-
-    np.testing.assert_array_equal(data_temp2["strings"], new_numeric)
-    np.testing.assert_array_equal(data_temp2["names"], new_numeric)
-
-    # test strings with input of size (6,2)
-    double_string_input = np.vstack((new_string.reshape(1,-1),
-                                     new_string.reshape(1,-1))).T
-    data_temp2[["integers","floats"]] = double_string_input
-
-    np.testing.assert_array_equal(data_temp2["integers"], new_string)
-    np.testing.assert_array_equal(data_temp2["floats"], new_string)
+    data_temp2 = data.copy()    
 
 @pytest.mark.parametrize("row_idx",
                         [slice(7, 8),

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -9,6 +9,7 @@ __date__ = "30 Apr 2022"
 import os
 
 import pytest
+import itertools
 import numpy as np
 import pandas as pd
 from pytest_lazyfixture import lazy_fixture
@@ -1163,3 +1164,109 @@ def test_is_str(df_simple):
 
     with pytest.raises(KeyError):
         navdata.is_str(0)
+
+def test_in_rows_single(data):
+    """Test the in_rows function.
+
+    Parameters
+    ----------
+    data : gnss_lib_py.parsers.navdata.NavData
+        Instance of NavData
+
+    """
+
+    # should not throw error
+    for row in data.rows:
+        data.in_rows(row)
+
+    # check removing a single row
+    for row in data.rows:
+        data_temp = data.copy()
+        data_temp = data_temp.remove(rows=[row])
+
+        ## lists
+        # check by passing in multiple rows
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows(data.rows)
+        assert row in str(excinfo.value)
+        # check by passing in single row
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows([row])
+        assert row in str(excinfo.value)
+
+        ## np.ndarrays
+        # check by passing in multiple rows
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows(np.array(data.rows))
+        assert row in str(excinfo.value)
+        # check by passing in single row
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows(np.array(row))
+        assert row in str(excinfo.value)
+
+        ## tuples
+        # check by passing in multiple rows
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows(tuple(data.rows))
+        assert row in str(excinfo.value)
+        # check by passing in single row
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows((row))
+        assert row in str(excinfo.value)
+
+        ## single value
+        # check by passing in single row
+        with pytest.raises(KeyError) as excinfo:
+            data_temp.in_rows(row)
+        assert row in str(excinfo.value)
+
+    # None of these should work
+    with pytest.raises(KeyError) as excinfo:
+        data_temp.in_rows(1)
+    assert "in_rows" in str(excinfo.value)
+
+    with pytest.raises(KeyError) as excinfo:
+        data_temp.in_rows(1.)
+    assert "in_rows" in str(excinfo.value)
+
+    with pytest.raises(KeyError) as excinfo:
+        data_temp.in_rows(np.nan)
+    assert "in_rows" in str(excinfo.value)
+
+def test_in_rows_multi(data):
+    """Test the in_rows function.
+
+    Parameters
+    ----------
+    data : gnss_lib_py.parsers.navdata.NavData
+        Instance of NavData
+
+    """
+
+    for choice in [2,3]:
+        for combo_rows in itertools.combinations(data.rows,choice):
+
+            # should pass without error
+            data.in_rows(combo_rows)
+
+            # remove multiple rows
+            data_temp = data.copy()
+            data_temp = data_temp.remove(rows=combo_rows)
+
+            # list
+            with pytest.raises(KeyError) as excinfo:
+                data_temp.in_rows(list(combo_rows))
+            for row in combo_rows:
+                assert row in str(excinfo.value)
+
+            # np.ndarray
+            with pytest.raises(KeyError) as excinfo:
+                data_temp.in_rows(np.array(combo_rows))
+            for row in combo_rows:
+                assert row in str(excinfo.value)
+
+            # tuple
+            with pytest.raises(KeyError) as excinfo:
+                data_temp.in_rows(combo_rows)
+            for row in combo_rows:
+                assert row in str(excinfo.value)

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -1603,19 +1603,33 @@ def test_is_str(df_simple):
     with pytest.raises(KeyError):
         navdata.is_str(0)
 
-def test_str_navdata(df_simple):
+def test_str_navdata(df_simple, df_only_header):
     """Test that the NavData class can be printed without errors
 
     Parameters
     ----------
     df_simple : pd.DataFrame
         Dataframe with which to construct NavData instance
+    df_only_header : pd.DataFrame
+        Dataframe with only column names and no data
     """
     navdata = NavData(pandas_df=df_simple)
     navdata_str = str(navdata)
     # Conversion from int to float in DataFrame for consistency
     df_simple = df_simple.astype({'integers': 'float64'})
     df_str = str(df_simple)
+    assert navdata_str==df_str
+
+    # make sure print doesn't break if given only headers
+    navdata_str = str(NavData(pandas_df=df_only_header))
+    df_str = str(df_only_header).replace("DataFrame","NavData")
+    df_str = df_str.replace("Columns","Rows")
+    assert navdata_str==df_str
+
+    # make sure it doesn't break with empty NavData
+    navdata_str = str(NavData())
+    df_str = str(pd.DataFrame()).replace("DataFrame","NavData")
+    df_str = df_str.replace("Columns","Rows")
     assert navdata_str==df_str
 
 def test_in_rows_single(data):

--- a/tests/parsers/test_navdata.py
+++ b/tests/parsers/test_navdata.py
@@ -576,6 +576,32 @@ def fixture_new_string():
                              'date', 'pear', 'lime'], dtype=object)
     return new_string
 
+@pytest.fixture(name="new_string_str")
+def fixture_new_string_string_type():
+    """String to test for value assignment
+
+    Returns
+    -------
+    new_string : np.ndarray
+        String of length 6 to test string assignment
+    """
+    new_string = np.asarray(['pie', 'cake', 'sherbert',
+                             'cookies', 'cupcake', 'brownies'],dtype=str)
+    return new_string
+
+@pytest.fixture(name="new_string_unicode")
+def fixture_new_string_unicode_type():
+    """String to test for value assignment
+
+    Returns
+    -------
+    new_string : np.ndarray
+        String of length 6 to test string assignment
+    """
+    new_string = np.asarray(['red', 'orange', 'yellow',
+                             'green', 'blue', 'purple'])
+    return new_string
+
 
 @pytest.fixture(name="new_str_list")
 def fixture_new_str_list(new_string):
@@ -623,10 +649,18 @@ def fixture_subsect_str_list(subset_str):
                         ('new_key_2d_col', np.ones([6,1]), np.ones([1,6])),
                         ('new_str_key', lazy_fixture('new_string'),
                          lazy_fixture('new_str_list')),
+                        ('new_str_key', lazy_fixture('new_string_str'),
+                         lazy_fixture('new_string_str')),
+                        ('new_str_key', lazy_fixture('new_string_unicode'),
+                         lazy_fixture('new_string_unicode')),
                         ('integers', 0, np.zeros([1,6])),
                         (1, 7, 7*np.ones([1,6])),
                         ('names', lazy_fixture('new_string'),
                          lazy_fixture('new_str_list')),
+                        ('names', lazy_fixture('new_string_str'),
+                         lazy_fixture('new_string_str')),
+                        ('names', lazy_fixture('new_string_unicode'),
+                         lazy_fixture('new_string_unicode')),
                         ((['integers', 'floats'], slice(1, 4)), -10,
                          -10*np.ones([2,3])),
                         (('strings', slice(2, 5)),


### PR DESCRIPTION
Major functionality additions to `NavData` !
- built-in print functionality
- `in_rows()` to check whether a row exists in NavData and raise an exception if it's not in NavData
- `**kwargs` for csv inputs
- ability to change datatypes of existing rows from numeric to string and vice versa
- ability to set 2D string arrays
- conformance of `rename` to pd.rename() where you can rename both rows and values inside of those rows. Allows you to rename values inside of rows and natively change the datatype of those rows if all rows are mapped to a new datatype
- added inplace tag to `remove`

**153 additional tests to validate the above functionality**