### PR TITLE
Added display in Jupyter notebook without print

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - v*.*.*
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v*.*.*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pip-install.yml
+++ b/.github/workflows/pip-install.yml
@@ -2,7 +2,9 @@ name: pip-install
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v*.*.*
   workflow_dispatch:
 
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,7 +2,9 @@ name: pylint
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v*.*.*
   workflow_dispatch:
 
 jobs:

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -1068,7 +1068,7 @@ class NavData():
                          str_out)
         return str_out
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         """Evaluated string representation of Navdata object
 
         For NavData objects, this is similar to the str method and is

--- a/gnss_lib_py/parsers/navdata.py
+++ b/gnss_lib_py/parsers/navdata.py
@@ -1051,6 +1051,14 @@ class NavData():
         return x_curr
 
     def __str__(self):
+        """Creates string representation of NavData object
+
+        Returns
+        -------
+        str_out : str
+            String representation of Navdata object, based on equivalent
+            Pandas string
+        """
         str_out = str(self.pandas_df())
         str_out = str_out.replace("DataFrame","NavData")
         str_out = str_out.replace("Columns","Rows")
@@ -1059,6 +1067,21 @@ class NavData():
                          r'\g<1>[\g<3> rows x \g<2> columns]\g<4>',
                          str_out)
         return str_out
+
+    def __repr__(self):
+        """Evaluated string representation of Navdata object
+
+        For NavData objects, this is similar to the str method and is
+        defined separately to avoid having to add a `print` method
+        before each display command in Jupyter notebooks
+
+        Returns
+        -------
+        rep_out : str
+            Evaluated string representation object
+        """
+        rep_out = str(self)
+        return rep_out
 
     def __len__(self):
         """Return length of class


### PR DESCRIPTION
Added a new function so that typing the name of the NavData instance in the end of a Jupyter cell prints the NavData instead of the standard '<instance of NavData at [memory location]>'.

Also created a pull request so that the readthedocs action runs and can be added as a status check to the new version branch rules.
