### PR TITLE
remove NaN values in RinexNav

### DIFF
--- a/gnss_lib_py/parsers/rinex_nav.py
+++ b/gnss_lib_py/parsers/rinex_nav.py
@@ -204,11 +204,11 @@ class RinexNav(NavData):
         else:
             data = gr.load(rinex_path,
                                  verbose=self.verbose).to_dataframe()
+        data.dropna(how='all', inplace=True)
+        data.reset_index(inplace=True)
         data_header = gr.rinexheader(rinex_path)
         leap_seconds = self.load_leapseconds(data_header)
         data['leap_seconds'] = leap_seconds
-        data.dropna(how='all', inplace=True)
-        data.reset_index(inplace=True)
         data['source'] = rinex_path
         data['t_oc'] = pd.to_numeric(data['time'] - consts.GPS_EPOCH_0.replace(tzinfo=None))
         data['t_oc']  = 1e-9 * data['t_oc'] - consts.WEEKSEC * np.floor(1e-9 * data['t_oc'] / consts.WEEKSEC)

--- a/tests/parsers/test_rinex_nav.py
+++ b/tests/parsers/test_rinex_nav.py
@@ -205,3 +205,18 @@ def test_no_iono_params(ephem_path):
     rinex_path = os.path.join(ephem_path,"rinex","nav",
                                    "BRDM00DLR_S_20230730000_01D_MN_no_gps_iono.rnx")
     RinexNav(rinex_path)
+
+def test_nan_removal(ephem_path):
+    """Test that NaN values are being removed appropriately.
+
+    Parameters
+    ----------
+    ephem_path : string
+        Location where ephemeris files are stored/to be downloaded to.
+
+    """
+
+    rinex_path = os.path.join(ephem_path,"rinex","nav",
+                                   "brdc0730.17n")
+    rinex_data = RinexNav(rinex_path)
+    assert rinex_data.shape == (36,4)


### PR DESCRIPTION
- Removes NaN rows that `georinex` outputs when parsing Rinex Nav data files
- Fixes #155 