### PR TITLE
Speed up parsing the NMEEA messages

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ Shivam Soni
 Sriramya Bhamidipati  
 Dalton Vega  
 Daniel Neamati
+Sandro Klarer

--- a/gnss_lib_py/parsers/nmea.py
+++ b/gnss_lib_py/parsers/nmea.py
@@ -133,9 +133,7 @@ class Nmea(NavData):
             date = field_dict.pop('datestamp')
             delta_t = datetime.datetime.combine(datestamp(date), timestamp(time))
             field_dict['gps_millis'] = datetime_to_gps_millis(delta_t)
-
             temporary_dictionary_list_df.append(field_dict)
-
         pd_df = pd.DataFrame.from_dict(temporary_dictionary_list_df)
         # As per `gnss_lib_py` standards, convert the heading from degrees
         # to radians

--- a/gnss_lib_py/parsers/nmea.py
+++ b/gnss_lib_py/parsers/nmea.py
@@ -67,7 +67,7 @@ class Nmea(NavData):
         if msg_types is None:
             # Use default message types
             msg_types = ['GGA', 'RMC']
-        pd_df = pd.DataFrame()
+        temporary_dictionary_list_df = []
         field_dict = {}
         prev_timestamp = None
 
@@ -101,8 +101,7 @@ class Nmea(NavData):
                             delta_t = datetime.datetime.combine(datestamp(date), timestamp(time))
                             field_dict['gps_millis'] = datetime_to_gps_millis(delta_t)
 
-                            new_row = pd.DataFrame([field_dict])
-                            pd_df = pd.concat([pd_df, new_row])
+                            temporary_dictionary_list_df.append(field_dict)
                             field_dict = {}
                             prev_timestamp = msg.timestamp
                     if "sentence_type" in msg.__dir__() and msg.sentence_type in msg_types:
@@ -134,8 +133,10 @@ class Nmea(NavData):
             date = field_dict.pop('datestamp')
             delta_t = datetime.datetime.combine(datestamp(date), timestamp(time))
             field_dict['gps_millis'] = datetime_to_gps_millis(delta_t)
-            new_row = pd.DataFrame([field_dict])
-            pd_df = pd.concat([pd_df, new_row])
+
+            temporary_dictionary_list_df.append(field_dict)
+
+        pd_df = pd.DataFrame.from_dict(temporary_dictionary_list_df)
         # As per `gnss_lib_py` standards, convert the heading from degrees
         # to radians
         pd_df['true_course_rad'] = (np.pi/180.)*pd_df['true_course']\


### PR DESCRIPTION
 Using the pandas concat() function is very time consuming. Changed it according to:
   [what-is-the-fastest-and-most-efficient-way-to-append-rows-to-a-dataframe]( https://stackoverflow.com/questions/57000903/what-is-the-fastest-and-most-efficient-way-to-append-rows-to-a-dataframehttps://stackoverflow.com/questions/57000903/what-is-the-fastest-and-most-efficient-way-to-append-rows-to-a-dataframe)
    
Parsing my 7receivers  day log (~800MB) of MNEA messages takes 3500s, now it takes 180s.
